### PR TITLE
fix deployed path prefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  pathPrefix: '/x86reference',
   siteMetadata: {
     title: 'x86reference',
     description: 'Quickly search x86 assembly documentation.',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "license": "0BSD",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "gatsby develop",


### PR DESCRIPTION
When deployed to GitHub Pages, the application is mounted under the `/x86reference` base path. This PR adds the `pathPrefix` option to `gatsby-config.js` and enables the `--prefix-paths` option when building to accomodate this.